### PR TITLE
add $Test::XML::Simple::XML_DOC

### DIFF
--- a/lib/Test/XML/Simple.pm
+++ b/lib/Test/XML/Simple.pm
@@ -10,8 +10,9 @@ use Test::More;
 use Test::LongString;
 use XML::LibXML;
 
+our $XML_DOC;
+
 my $Test = Test::Builder->new();
-my $Xml;
 my $last_xml_string = "";
 
 sub import {
@@ -41,16 +42,19 @@ sub xml_valid($;$) {
 
 sub _valid_xml {
   my $xml = shift;
-  return $Xml if defined($xml) and $xml eq $last_xml_string;
+  return $XML_DOC if defined($xml) and $xml eq $last_xml_string;
  
   local $Test::Builder::Level = $Test::Builder::Level + 2; 
   return fail("XML is not defined") unless defined $xml;
   return fail("XML is missing")     unless $xml;
   return fail("string can't contain XML: no tags") 
     unless ($xml =~ /</ and $xml =~/>/);
-  eval {$Xml = XML::LibXML->new->parse_string($xml)};
-  $@ ? do { chomp $@; return fail($@) }
-     : return $Xml;
+  eval { $XML_DOC = XML::LibXML->new->parse_string($xml); };
+  if ($@) {
+      chomp $@;
+      return fail($@);
+  }
+  return $XML_DOC;
 }
 
 sub _find {
@@ -251,6 +255,12 @@ Find the piece of XML corresponding to the XPath expression,
 and compare its structure and contents to the second XML
 (fragment) supplied. Succeeds if they match in structure and
 content. Uses Test::LongString's C<is_string> function to do the test.
+
+=head1 ADDITIONAL VARIABLES
+
+=head2 $Test::XML::Simple::XML_DOC
+
+Contain a 'XML::LibXML::Document' object which was used in previous test.
 
 =head1 AUTHOR
 

--- a/t/90_xml_doc.t
+++ b/t/90_xml_doc.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::Builder::Tester tests => 1;
+use Test::More;
+use Test::XML::Simple;
+
+my $xml = <<'EOS';
+<CATALOG>
+  <CD>
+    <TITLE>Sacred Love</TITLE>
+    <ARTIST>Sting</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>A&amp;M</COMPANY>
+    <PRICE>12.99</PRICE>
+
+    <YEAR>2003</YEAR>
+  </CD>
+</CATALOG>
+EOS
+
+test_out( 'ok 1 - xml', 'ok 2 - $XML_DOC is a XML::LibXML::Document' );
+xml_valid( $xml, 'xml' );
+my $xml_doc = do {
+    no warnings 'once';    ## no critic (TestingAndDebugging::ProhibitNoWarnings)
+    $Test::XML::Simple::XML_DOC;
+};
+is( ref($xml_doc), 'XML::LibXML::Document', '$XML_DOC is a XML::LibXML::Document' );
+test_test('$XML_DOC is a XML::LibXML::Document');


### PR DESCRIPTION
which contain 'XML::LibXML::Document' object used in last test

so we can reuse it in tests. like for get some nodes, etc
