### PR TITLE
Fix is_xml() return

### DIFF
--- a/lib/Test/XML/Simple.pm
+++ b/lib/Test/XML/Simple.pm
@@ -80,7 +80,7 @@ sub xml_node($$;$) {
 
 
 sub xml_is($$$;$) {
-  _xml_is(\&is_string, @_);
+  return _xml_is( \&is_string, @_ );
 }
 
 sub xml_is_long($$$;$) {
@@ -97,17 +97,24 @@ sub _xml_is {
   my $nodeset = _find($parsed_xml, $xpath);
   return 0 if !$nodeset;
 
+  my $ok = 1;
   foreach my $node (@$nodeset) {
     my @kids = $node->getChildNodes;
+    my $node_ok;
     if (@kids) {
-      $comp_sub->($kids[0]->toString, $value, $comment);
+      $node_ok = $comp_sub->( $kids[0]->toString, $value, $comment );
     }
     else {
-      my $got =  $node->toString;
+      my $got = $node->toString;
       $got =~ s/^.*="(.*)"/$1/;
-      is $got, $value, $comment;
+      $node_ok = is $got, $value, $comment;
     }
+
+    # returns NOT OK if even one of tests fails
+    $ok = 0 unless $node_ok;
   }
+
+  return $ok;
 }
 
 sub xml_is_deeply($$$;$) {

--- a/t/05is.t
+++ b/t/05is.t
@@ -33,8 +33,9 @@ xml_is_long($xml, "/CATALOG/CD/ARTIST", 'Sting', "full path");
 test_test("long node match");
 
 test_out('not ok 1 - good node');
+my $line = line_num(+8);
 test_err(qq<#   Failed test 'good node'
-#   at t/05is.t line 43.
+#   at $0 line $line.
 #          got: "Sting"
 #       length: 5
 #     expected: "Weird Al"
@@ -44,8 +45,9 @@ xml_is($xml, "//ARTIST", 'Weird Al', "good node");
 test_test("node miss");
 
 test_out('not ok 1 - full path');
+$line = line_num(+8);
 test_err(qq<#   Failed test 'full path'
-#   at t/05is.t line 54.
+#   at $0 line $line.
 #          got: "Sting"
 #       length: 5
 #     expected: "Weird Al"

--- a/t/05is.t
+++ b/t/05is.t
@@ -1,5 +1,5 @@
 use Test::Builder::Tester;
-use Test::More tests=>6;
+use Test::More tests => 7;
 use Test::XML::Simple;
 
 my $xml = <<EOS;
@@ -17,8 +17,9 @@ my $xml = <<EOS;
 EOS
 
 test_out("ok 1 - good node");
-xml_is($xml, "//ARTIST", 'Sting', "good node");
+my $ok = xml_is( $xml, "//ARTIST", 'Sting', "good node" );
 test_test("node match");
+ok( $ok, 'xml_is() return true for "node match"' );
 
 test_out('ok 1 - good node');
 xml_is_long($xml, "//ARTIST", 'Sting', "good node");

--- a/t/09is_for_multi_nodes.t
+++ b/t/09is_for_multi_nodes.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::Builder::Tester;
+use Test::More tests => 6;
+use Test::XML::Simple;
+
+my $xml = <<EOS;
+<CATALOG>
+  <CD>
+    <TITLE>Sacred Love</TITLE>
+    <ARTIST>Sting</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>A&amp;M</COMPANY>
+    <PRICE>12.99</PRICE>
+    <YEAR>2003</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Another Great Album</TITLE>
+    <ARTIST>Sting</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>A&amp;M</COMPANY>
+    <PRICE>12.99</PRICE>
+    <YEAR>2003</YEAR>
+  </CD>
+</CATALOG>
+EOS
+
+test_out( 'ok 1', 'ok 2' );
+my $ok = xml_is( $xml, "//ARTIST", 'Sting' );
+test_test('all nodes are equal');
+ok( $ok, 'xml_is() return true for "all nodes are equal"' );
+
+test_out( 'ok 1', 'not ok 2' );
+my $line_num = line_num(+2);
+test_err(qr/#\s+Failed test.*at $0 line $line_num.*/s);
+$ok = xml_is( $xml, '//TITLE', 'Sacred Love' );
+test_test('different nodes values');
+ok( !$ok, 'xml_is() return false for "different nodes values"' );
+
+test_out( 'not ok 1', 'ok 2' );
+$line_num = line_num(+2);
+test_err(qr/#\s+Failed test.*at $0 line $line_num.*/s);
+$ok = xml_is( $xml, '//TITLE', 'Another Great Album' );
+test_test('different nodes values, another order');
+ok( !$ok, 'xml_is() return false for "different nodes values"' );


### PR DESCRIPTION
is_xml() returns undef even if all tests under it are fine.
This is uncommon behaviour and disallow to use like: `is_xml(...) or return`, `is_xml(...) or BAIL_OUT...`

The patch fix that and also provide tests for a case when multi nodes affected by XPATH